### PR TITLE
fix(#152) - Restore send date meta if newsletter processing is aborted

### DIFF
--- a/includes/Mail/Queue.php
+++ b/includes/Mail/Queue.php
@@ -74,8 +74,23 @@ class Queue
             return;
         }
 
+        $currentSendDateGmt = $post->post_date_gmt ?: get_gmt_from_date($post->post_date);
+        $hadPreviousSendDateGmt = metadata_exists('post', $postId, 'rrze_newsletter_send_date_gmt');
+        $previousSendDateGmt = $hadPreviousSendDateGmt ? get_post_meta($postId, 'rrze_newsletter_send_date_gmt', true) : '';
+        update_post_meta($postId, 'rrze_newsletter_send_date_gmt', $currentSendDateGmt);
+
+        $restoreSendDateMeta = static function () use ($hadPreviousSendDateGmt, $previousSendDateGmt, $postId) {
+            if ($hadPreviousSendDateGmt) {
+                update_post_meta($postId, 'rrze_newsletter_send_date_gmt', $previousSendDateGmt);
+                return;
+            }
+
+            delete_post_meta($postId, 'rrze_newsletter_send_date_gmt');
+        };
+
         $data = Newsletter::getData($postId);
         if (empty($data) || is_wp_error($data)) {
+            $restoreSendDateMeta();
             Newsletter::setStatus($postId, 'error');
             do_action(
                 'rrze.log.error',
@@ -93,6 +108,7 @@ class Queue
 
         // Check if it should be skipped.
         if ($this->maybeSkipped($postId)) {
+            $restoreSendDateMeta();
             // Set the newsletter status to 'skipped'.
             Newsletter::setStatus($postId, 'skipped');
             return;
@@ -157,6 +173,7 @@ class Queue
         }
 
         if (empty($recipient)) {
+            $restoreSendDateMeta();
             Newsletter::setStatus($postId, 'error');
             do_action(
                 'rrze.log.error',


### PR DESCRIPTION
Reverts the `rrze_newsletter_send_date_gmt` metadata to its previous state if the mail queue exits early due to empty data, skipping logic, or a lack of recipients. This ensures that the post meta accurately reflects the newsletter's status when a mailing is not successfully completed. #152